### PR TITLE
Add LineNumbers to all Visitees

### DIFF
--- a/comment_test.go
+++ b/comment_test.go
@@ -28,11 +28,11 @@ import (
 )
 
 func TestCreateComment(t *testing.T) {
-	c0 := newComment("")
+	c0 := newComment(0, "")
 	if got, want := len(c0.Lines), 1; got != want {
 		t.Errorf("got [%v] want [%v]", got, want)
 	}
-	c1 := newComment(`hello
+	c1 := newComment(0, `hello
 world`)
 	if got, want := len(c1.Lines), 2; got != want {
 		t.Errorf("got [%v] want [%v]", got, want)
@@ -49,8 +49,8 @@ world`)
 }
 
 func TestTakeLastComment(t *testing.T) {
-	c0 := newComment("hi")
-	c1 := newComment("there")
+	c0 := newComment(0, "hi")
+	c1 := newComment(0, "there")
 	_, l := takeLastComment([]Visitee{c0, c1})
 	if got, want := len(l), 1; got != want {
 		t.Fatalf("got [%v] want [%v]", got, want)
@@ -83,6 +83,9 @@ func TestParseCommentWithEmptyLinesAndTripleSlash(t *testing.T) {
 	if got, want := def.Elements[0].(*Comment).Lines[4], " comment 4"; got != want {
 		t.Fatalf("got [%v] want [%v]", got, want)
 	}
+	if got, want := def.Elements[0].(*Comment).LineNumber, 2; got != want {
+		t.Fatalf("got [%d] want [%d]", got, want)
+	}
 }
 
 func TestParseCommentWithTripleSlash(t *testing.T) {
@@ -103,5 +106,8 @@ func TestParseCommentWithTripleSlash(t *testing.T) {
 	}
 	if got, want := def.Elements[0].(*Comment).Lines[0], " comment 1"; got != want {
 		t.Fatalf("got [%v] want [%v]", got, want)
+	}
+	if got, want := def.Elements[0].(*Comment).LineNumber, 2; got != want {
+		t.Fatalf("got [%d] want [%d]", got, want)
 	}
 }

--- a/enum_test.go
+++ b/enum_test.go
@@ -26,7 +26,7 @@ package proto
 import "testing"
 
 func TestEnum(t *testing.T) {
-	proto := `	
+	proto := `
 // enum
 enum EnumAllowingAlias {
   option allow_alias = true;
@@ -52,9 +52,15 @@ enum EnumAllowingAlias {
 	if got, want := enums[0].Comment.Message(), " enum"; got != want {
 		t.Errorf("got [%v] want [%v]", enums[0].Comment, want)
 	}
+	if got, want := enums[0].LineNumber, 3; got != want {
+		t.Errorf("got [%d] want [%d]", got, want)
+	}
 	ef1 := enums[0].Elements[1].(*EnumField)
 	if got, want := ef1.Integer, 0; got != want {
 		t.Errorf("got [%v] want [%v]", got, want)
+	}
+	if got, want := ef1.LineNumber, 5; got != want {
+		t.Errorf("got [%d] want [%d]", got, want)
 	}
 	ef3 := enums[0].Elements[3].(*EnumField)
 	if got, want := ef3.Integer, 2; got != want {
@@ -65,5 +71,8 @@ enum EnumAllowingAlias {
 	}
 	if got, want := ef3.ValueOption.Constant.Source, "hello world"; got != want {
 		t.Errorf("got [%v] want [%v]", got, want)
+	}
+	if got, want := ef3.LineNumber, 7; got != want {
+		t.Errorf("got [%d] want [%d]", got, want)
 	}
 }

--- a/extensions.go
+++ b/extensions.go
@@ -26,6 +26,7 @@ package proto
 // Extensions declare that a range of field numbers in a message are available for third-party extensions.
 // proto2 only
 type Extensions struct {
+	LineNumber    int
 	Comment       *Comment
 	Ranges        []Range
 	InlineComment *Comment

--- a/extensions_test.go
+++ b/extensions_test.go
@@ -26,7 +26,7 @@ package proto
 import "testing"
 
 func TestExtensions(t *testing.T) {
-	proto := `message M { 
+	proto := `message M {
 		// extensions
 		extensions 4, 20 to max; // max
 	}`
@@ -42,6 +42,9 @@ func TestExtensions(t *testing.T) {
 	}
 	f := m.Elements[0].(*Extensions)
 	if got, want := len(f.Ranges), 2; got != want {
+		t.Fatalf("got [%d] want [%d]", got, want)
+	}
+	if got, want := f.LineNumber, 3; got != want {
 		t.Fatalf("got [%d] want [%d]", got, want)
 	}
 	if got, want := f.Ranges[1].String(), "20 to max"; got != want {

--- a/field_test.go
+++ b/field_test.go
@@ -60,6 +60,9 @@ func TestField(t *testing.T) {
 	if got, want := f.Options[2].Constant.Source, "happy"; got != want {
 		t.Errorf("got [%v] want [%v]", got, want)
 	}
+	if got, want := f.LineNumber, 1; got != want {
+		t.Errorf("got [%v] want [%v]", got, want)
+	}
 }
 
 func TestFieldSimple(t *testing.T) {

--- a/group.go
+++ b/group.go
@@ -26,11 +26,12 @@ package proto
 // Group represents a (proto2 only) group.
 // https://developers.google.com/protocol-buffers/docs/reference/proto2-spec#group_field
 type Group struct {
-	Comment  *Comment
-	Name     string
-	Optional bool
-	Sequence int
-	Elements []Visitee
+	LineNumber int
+	Comment    *Comment
+	Name       string
+	Optional   bool
+	Sequence   int
+	Elements   []Visitee
 }
 
 // Accept dispatches the call to the visitor.
@@ -63,14 +64,14 @@ func (g *Group) takeLastComment() (last *Comment) {
 // parse expects:
 // groupName "=" fieldNumber { messageBody }
 func (g *Group) parse(p *Parser) error {
-	tok, lit := p.scanIgnoreWhitespace()
+	_, tok, lit := p.scanIgnoreWhitespace()
 	if tok != tIDENT {
 		if !isKeyword(tok) {
 			return p.unexpected(lit, "group name", g)
 		}
 	}
 	g.Name = lit
-	tok, lit = p.scanIgnoreWhitespace()
+	_, tok, lit = p.scanIgnoreWhitespace()
 	if tok != tEQUALS {
 		return p.unexpected(lit, "group =", g)
 	}
@@ -79,7 +80,7 @@ func (g *Group) parse(p *Parser) error {
 		return p.unexpected(lit, "group sequence number", g)
 	}
 	g.Sequence = i
-	tok, lit = p.scanIgnoreWhitespace()
+	_, tok, lit = p.scanIgnoreWhitespace()
 	if tok != tLEFTCURLY {
 		return p.unexpected(lit, "group opening {", g)
 	}

--- a/group_test.go
+++ b/group_test.go
@@ -47,6 +47,9 @@ func TestGroup(t *testing.T) {
 	if got, want := len(g.Elements), 1; got != want {
 		t.Fatalf("got [%v] want [%v]", got, want)
 	}
+	if got, want := g.LineNumber, 3; got != want {
+		t.Fatalf("got [%v] want [%v]", got, want)
+	}
 	if got, want := g.Comment != nil, true; got != want {
 		t.Errorf("got [%v] want [%v]", got, want)
 	}

--- a/import.go
+++ b/import.go
@@ -27,6 +27,7 @@ import "fmt"
 
 // Import holds a filename to another .proto definition.
 type Import struct {
+	LineNumber    int
 	Comment       *Comment
 	Filename      string
 	Kind          string // weak, public, <empty>
@@ -34,7 +35,7 @@ type Import struct {
 }
 
 func (i *Import) parse(p *Parser) error {
-	tok, lit := p.scanIgnoreWhitespace()
+	_, tok, lit := p.scanIgnoreWhitespace()
 	switch tok {
 	case tWEAK:
 		i.Kind = lit

--- a/message_test.go
+++ b/message_test.go
@@ -32,7 +32,7 @@ func TestMessage(t *testing.T) {
 		string   id  = 1;
 		// size
 		int64   size = 2;
-		
+
 		oneof foo {
 			string     name        = 4;
 			SubMessage sub_message = 9;
@@ -54,6 +54,18 @@ func TestMessage(t *testing.T) {
 		t.Errorf("got [%v] want [%v]", got, want)
 	}
 	if got, want := len(m.Elements), 6; got != want {
+		t.Errorf("got [%v] want [%v]", got, want)
+	}
+	if got, want := m.Elements[0].(*NormalField).LineNumber, 4; got != want {
+		t.Errorf("got [%v] want [%v]", got, want)
+	}
+	if got, want := m.Elements[0].(*NormalField).Comment.LineNumber, 3; got != want {
+		t.Errorf("got [%v] want [%v]", got, want)
+	}
+	if got, want := m.Elements[3].(*Message).LineNumber, 12; got != want {
+		t.Errorf("got [%v] want [%v]", got, want)
+	}
+	if got, want := m.Elements[3].(*Message).Elements[0].(*NormalField).LineNumber, 13; got != want {
 		t.Errorf("got [%v] want [%v]", got, want)
 	}
 }

--- a/oneof_test.go
+++ b/oneof_test.go
@@ -48,6 +48,9 @@ func TestOneof(t *testing.T) {
 	if got, want := first.Comment.Message(), " just a name"; got != want {
 		t.Errorf("got [%v] want [%v]", got, want)
 	}
+	if got, want := first.LineNumber, 3; got != want {
+		t.Errorf("got [%v] want [%v]", got, want)
+	}
 	second := o.Elements[1].(*OneOfField)
 	if got, want := second.Name, "sub_message"; got != want {
 		t.Errorf("got [%v] want [%v]", got, want)
@@ -56,6 +59,9 @@ func TestOneof(t *testing.T) {
 		t.Errorf("got [%v] want [%v]", got, want)
 	}
 	if got, want := second.Sequence, 9; got != want {
+		t.Errorf("got [%v] want [%v]", got, want)
+	}
+	if got, want := second.LineNumber, 4; got != want {
 		t.Errorf("got [%v] want [%v]", got, want)
 	}
 }

--- a/option_test.go
+++ b/option_test.go
@@ -125,6 +125,15 @@ option Help = "me"; // inline`
 	if got, want := o.InlineComment.Lines[0], " inline"; got != want {
 		t.Fatalf("got [%v] want [%v]", got, want)
 	}
+	if got, want := o.LineNumber, 3; got != want {
+		t.Fatalf("got [%v] want [%v]", got, want)
+	}
+	if got, want := o.Comment.LineNumber, 2; got != want {
+		t.Fatalf("got [%v] want [%v]", got, want)
+	}
+	if got, want := o.InlineComment.LineNumber, 3; got != want {
+		t.Fatalf("got [%v] want [%v]", got, want)
+	}
 }
 
 func TestIssue8(t *testing.T) {
@@ -162,6 +171,21 @@ message Bar {
 		t.Fatalf("got [%v] want [%v]", got, want)
 	}
 	if got, want := ac[1].Source, "baz"; got != want {
+		t.Fatalf("got [%v] want [%v]", got, want)
+	}
+	if got, want := o.LineNumber, 3; got != want {
+		t.Fatalf("got [%v] want [%v]", got, want)
+	}
+	if got, want := o.Comment.LineNumber, 2; got != want {
+		t.Fatalf("got [%v] want [%v]", got, want)
+	}
+	if got, want := f.LineNumber, 5; got != want {
+		t.Fatalf("got [%v] want [%v]", got, want)
+	}
+	if got, want := ac[0].LineNumber, 6; got != want {
+		t.Fatalf("got [%v] want [%v]", got, want)
+	}
+	if got, want := ac[1].LineNumber, 7; got != want {
 		t.Fatalf("got [%v] want [%v]", got, want)
 	}
 }

--- a/package.go
+++ b/package.go
@@ -25,6 +25,7 @@ package proto
 
 // Package specifies the namespace for all proto elements.
 type Package struct {
+	LineNumber    int
 	Comment       *Comment
 	Name          string
 	InlineComment *Comment
@@ -36,7 +37,7 @@ func (p *Package) Doc() *Comment {
 }
 
 func (p *Package) parse(pr *Parser) error {
-	tok, lit := pr.scanIgnoreWhitespace()
+	_, tok, lit := pr.scanIgnoreWhitespace()
 	if tIDENT != tok {
 		if !isKeyword(tok) {
 			return pr.unexpected(lit, "package identifier", p)

--- a/parser.go
+++ b/parser.go
@@ -33,9 +33,10 @@ import (
 type Parser struct {
 	s   *scanner
 	buf struct {
-		tok token  // last read token
-		lit string // last read literal
-		n   int    // buffer size (max=1)
+		line int
+		tok  token  // last read token
+		lit  string // last read literal
+		n    int    // buffer size (max=1)
 	}
 	debug bool
 }
@@ -53,27 +54,27 @@ func (p *Parser) Parse() (*Proto, error) {
 
 // scan returns the next token from the underlying scanner.
 // If a token has been unscanned then read that instead.
-func (p *Parser) scan() (tok token, lit string) {
+func (p *Parser) scan() (line int, tok token, lit string) {
 	// If we have a token on the buffer, then return it.
 	if p.buf.n != 0 {
 		p.buf.n = 0
-		return p.buf.tok, p.buf.lit
+		return p.buf.line, p.buf.tok, p.buf.lit
 	}
 
 	// Otherwise read the next token from the scanner.
-	tok, lit = p.s.scan()
+	line, tok, lit = p.s.scan()
 
 	// Save it to the buffer in case we unscan later.
-	p.buf.tok, p.buf.lit = tok, lit
+	p.buf.line, p.buf.tok, p.buf.lit = line, tok, lit
 
 	return
 }
 
 // scanIgnoreWhitespace scans the next non-whitespace token.
-func (p *Parser) scanIgnoreWhitespace() (tok token, lit string) {
-	tok, lit = p.scan()
+func (p *Parser) scanIgnoreWhitespace() (line int, tok token, lit string) {
+	line, tok, lit = p.scan()
 	if tok == tWS {
-		tok, lit = p.scan()
+		line, tok, lit = p.scan()
 	}
 	return
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -33,8 +33,8 @@ func TestParseComment(t *testing.T) {
     // first
 	// second
 
-    /* 
-	ctyle 
+    /*
+	ctyle
 	multi
 	line
     */
@@ -63,7 +63,7 @@ func newParserOn(def string) *Parser {
 // TEMPORARY tests
 func TestScanIgnoreWhitespace_Digits(t *testing.T) {
 	p := newParserOn("1234")
-	_, lit := p.scanIgnoreWhitespace()
+	_, _, lit := p.scanIgnoreWhitespace()
 	if got, want := lit, "1"; got != want {
 		t.Errorf("got [%v] want [%v]", got, want)
 	}
@@ -71,7 +71,7 @@ func TestScanIgnoreWhitespace_Digits(t *testing.T) {
 
 func TestScanIgnoreWhitespace_Minus(t *testing.T) {
 	p := newParserOn("-1234")
-	_, lit := p.scanIgnoreWhitespace()
+	_, _, lit := p.scanIgnoreWhitespace()
 	if got, want := lit, "-"; got != want {
 		t.Errorf("got [%v] want [%v]", got, want)
 	}

--- a/proto.go
+++ b/proto.go
@@ -48,14 +48,15 @@ func (proto *Proto) takeLastComment() (last *Comment) {
 // parse parsers a complete .proto definition source.
 func (proto *Proto) parse(p *Parser) error {
 	for {
-		tok, lit := p.scanIgnoreWhitespace()
+		line, tok, lit := p.scanIgnoreWhitespace()
 		switch tok {
 		case tCOMMENT:
-			if com := mergeOrReturnComment(proto.Elements, lit, p.s.line); com != nil { // not merged?
+			if com := mergeOrReturnComment(proto.Elements, lit, line); com != nil { // not merged?
 				proto.Elements = append(proto.Elements, com)
 			}
 		case tOPTION:
 			o := new(Option)
+			o.LineNumber = line
 			o.Comment, proto.Elements = takeLastComment(proto.Elements)
 			if err := o.parse(p); err != nil {
 				return err
@@ -63,6 +64,7 @@ func (proto *Proto) parse(p *Parser) error {
 			proto.Elements = append(proto.Elements, o)
 		case tSYNTAX:
 			s := new(Syntax)
+			s.LineNumber = line
 			s.Comment, proto.Elements = takeLastComment(proto.Elements)
 			if err := s.parse(p); err != nil {
 				return err
@@ -70,6 +72,7 @@ func (proto *Proto) parse(p *Parser) error {
 			proto.Elements = append(proto.Elements, s)
 		case tIMPORT:
 			im := new(Import)
+			im.LineNumber = line
 			im.Comment, proto.Elements = takeLastComment(proto.Elements)
 			if err := im.parse(p); err != nil {
 				return err
@@ -77,6 +80,7 @@ func (proto *Proto) parse(p *Parser) error {
 			proto.Elements = append(proto.Elements, im)
 		case tENUM:
 			enum := new(Enum)
+			enum.LineNumber = line
 			enum.Comment, proto.Elements = takeLastComment(proto.Elements)
 			if err := enum.parse(p); err != nil {
 				return err
@@ -84,6 +88,7 @@ func (proto *Proto) parse(p *Parser) error {
 			proto.Elements = append(proto.Elements, enum)
 		case tSERVICE:
 			service := new(Service)
+			service.LineNumber = line
 			service.Comment, proto.Elements = takeLastComment(proto.Elements)
 			err := service.parse(p)
 			if err != nil {
@@ -92,6 +97,7 @@ func (proto *Proto) parse(p *Parser) error {
 			proto.Elements = append(proto.Elements, service)
 		case tPACKAGE:
 			pkg := new(Package)
+			pkg.LineNumber = line
 			pkg.Comment, proto.Elements = takeLastComment(proto.Elements)
 			if err := pkg.parse(p); err != nil {
 				return err
@@ -99,6 +105,7 @@ func (proto *Proto) parse(p *Parser) error {
 			proto.Elements = append(proto.Elements, pkg)
 		case tMESSAGE:
 			msg := new(Message)
+			msg.LineNumber = line
 			msg.Comment, proto.Elements = takeLastComment(proto.Elements)
 			if err := msg.parse(p); err != nil {
 				return err
@@ -107,6 +114,7 @@ func (proto *Proto) parse(p *Parser) error {
 		// BEGIN proto2
 		case tEXTEND:
 			msg := new(Message)
+			msg.LineNumber = line
 			msg.Comment, proto.Elements = takeLastComment(proto.Elements)
 			msg.IsExtend = true
 			if err := msg.parse(p); err != nil {

--- a/range_test.go
+++ b/range_test.go
@@ -28,7 +28,7 @@ import "testing"
 func TestParseRanges(t *testing.T) {
 	r := new(Reserved)
 	p := newParserOn(`reserved 2, 15, 9 to 11;`)
-	_, _ = p.scanIgnoreWhitespace()
+	_, _, _ = p.scanIgnoreWhitespace()
 	ranges, err := parseRanges(p, r)
 	if err != nil {
 		t.Fatal(err)
@@ -41,7 +41,7 @@ func TestParseRanges(t *testing.T) {
 func TestParseRangesMax(t *testing.T) {
 	r := new(Extensions)
 	p := newParserOn(`extensions 3 to max;`)
-	_, _ = p.scanIgnoreWhitespace()
+	_, _, _ = p.scanIgnoreWhitespace()
 	ranges, err := parseRanges(p, r)
 	if err != nil {
 		t.Fatal(err)
@@ -54,7 +54,7 @@ func TestParseRangesMax(t *testing.T) {
 func TestParseRangesMultiToMax(t *testing.T) {
 	r := new(Extensions)
 	p := newParserOn(`extensions 1,2 to 5,6 to 9,10 to max;`)
-	_, _ = p.scanIgnoreWhitespace()
+	_, _, _ = p.scanIgnoreWhitespace()
 	ranges, err := parseRanges(p, r)
 	if err != nil {
 		t.Fatal(err)

--- a/reserved.go
+++ b/reserved.go
@@ -25,6 +25,7 @@ package proto
 
 // Reserved statements declare a range of field numbers or field names that cannot be used in a message.
 type Reserved struct {
+	LineNumber    int
 	Comment       *Comment
 	Ranges        []Range
 	FieldNames    []string
@@ -43,7 +44,7 @@ func (r *Reserved) Accept(v Visitor) {
 
 func (r *Reserved) parse(p *Parser) error {
 	for {
-		tok, lit := p.scanIgnoreWhitespace()
+		_, tok, lit := p.scanIgnoreWhitespace()
 		if len(lit) == 0 {
 			return p.unexpected(lit, "reserved string or integer", r)
 		}

--- a/reserved_test.go
+++ b/reserved_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2017 Ernest Micklei
-// 
+//
 // MIT License
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
 // "Software"), to deal in the Software without restriction, including
@@ -9,10 +9,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -28,7 +28,7 @@ import "testing"
 func TestReservedRanges(t *testing.T) {
 	r := new(Reserved)
 	p := newParserOn(`reserved 2, 15, 9 to 11;`)
-	tok, _ := p.scanIgnoreWhitespace()
+	_, tok, _ := p.scanIgnoreWhitespace()
 	if tRESERVED != tok {
 		t.Fail()
 	}
@@ -47,7 +47,7 @@ func TestReservedRanges(t *testing.T) {
 func TestReservedFieldNames(t *testing.T) {
 	r := new(Reserved)
 	p := newParserOn(`reserved "foo", "bar";`)
-	_, _ = p.scanIgnoreWhitespace()
+	_, _, _ = p.scanIgnoreWhitespace()
 	err := r.parse(p)
 	if err != nil {
 		t.Fatal(err)

--- a/scanner.go
+++ b/scanner.go
@@ -45,59 +45,61 @@ func newScanner(r io.Reader) *scanner {
 }
 
 // scan returns the next token and literal value.
-func (s *scanner) scan() (tok token, lit string) {
+func (s *scanner) scan() (line int, tok token, lit string) {
 	// Read the next rune.
 	ch := s.read()
-
+	line = s.line
 	// If we see whitespace then consume all contiguous whitespace.
 	// If we see a letter then consume as an ident or reserved word.
 	// If we see a slash then consume all as a comment (can be multiline)
 	if isWhitespace(ch) {
 		s.unread(ch)
-		return s.scanWhitespace()
+		tok, lit = s.scanWhitespace()
+		return
 	} else if isLetter(ch) || ch == '_' {
 		s.unread(ch)
-		return s.scanIdent()
+		tok, lit = s.scanIdent()
+		return
 	}
 
 	// Otherwise read the individual character.
 	switch ch {
 	case eof:
-		return tEOF, ""
+		return line, tEOF, ""
 	case ';':
-		return tSEMICOLON, string(ch)
+		return line, tSEMICOLON, string(ch)
 	case ':':
-		return tCOLON, string(ch)
+		return line, tCOLON, string(ch)
 	case '=':
-		return tEQUALS, string(ch)
+		return line, tEQUALS, string(ch)
 	case '"':
-		return tQUOTE, string(ch)
+		return line, tQUOTE, string(ch)
 	case '\'':
-		return tSINGLEQUOTE, string(ch)
+		return line, tSINGLEQUOTE, string(ch)
 	case '(':
-		return tLEFTPAREN, string(ch)
+		return line, tLEFTPAREN, string(ch)
 	case ')':
-		return tRIGHTPAREN, string(ch)
+		return line, tRIGHTPAREN, string(ch)
 	case '{':
-		return tLEFTCURLY, string(ch)
+		return line, tLEFTCURLY, string(ch)
 	case '}':
-		return tRIGHTCURLY, string(ch)
+		return line, tRIGHTCURLY, string(ch)
 	case '[':
-		return tLEFTSQUARE, string(ch)
+		return line, tLEFTSQUARE, string(ch)
 	case ']':
-		return tRIGHTSQUARE, string(ch)
+		return line, tRIGHTSQUARE, string(ch)
 	case '/':
-		return tCOMMENT, s.scanComment()
+		return line, tCOMMENT, s.scanComment()
 	case '<':
-		return tLESS, string(ch)
+		return line, tLESS, string(ch)
 	case ',':
-		return tCOMMA, string(ch)
+		return line, tCOMMA, string(ch)
 	case '.':
-		return tDOT, string(ch)
+		return line, tDOT, string(ch)
 	case '>':
-		return tGREATER, string(ch)
+		return line, tGREATER, string(ch)
 	}
-	return tILLEGAL, string(ch)
+	return line, tILLEGAL, string(ch)
 }
 
 // skipWhitespace consumes all whitespace until eof or a non-whitespace rune.

--- a/service_test.go
+++ b/service_test.go
@@ -29,7 +29,7 @@ func TestService(t *testing.T) {
 	proto := `service AccountService {
 		// comment
 		rpc CreateAccount (CreateAccount) returns (ServiceFault);
-		rpc GetAccounts   (stream Int64)  returns (Account);	
+		rpc GetAccounts   (stream Int64)  returns (Account);
 	}`
 	pr, err := newParserOn(proto).Parse()
 	if err != nil {
@@ -39,11 +39,17 @@ func TestService(t *testing.T) {
 	if got, want := len(srv.Elements), 2; got != want {
 		t.Fatalf("got [%v] want [%v]", got, want)
 	}
+	if got, want := srv.LineNumber, 1; got != want {
+		t.Fatalf("got [%v] want [%v]", got, want)
+	}
 	rpc1 := srv.Elements[0].(*RPC)
 	if got, want := rpc1.Name, "CreateAccount"; got != want {
 		t.Fatalf("got [%v] want [%v]", got, want)
 	}
 	if got, want := rpc1.Doc().Message(), " comment"; got != want {
+		t.Fatalf("got [%v] want [%v]", got, want)
+	}
+	if got, want := rpc1.LineNumber, 3; got != want {
 		t.Fatalf("got [%v] want [%v]", got, want)
 	}
 	rpc2 := srv.Elements[1].(*RPC)
@@ -57,9 +63,9 @@ func TestRPCWithOptionAggregateSyntax(t *testing.T) {
 		// CreateAccount
 		rpc CreateAccount (CreateAccount) returns (ServiceFault){
 			option (test_ident) = {
-				test: "test" 
+				test: "test"
 				test2:"test2"
-			};			
+			};
 		}
 	}`
 	pr, err := newParserOn(proto).Parse()

--- a/syntax.go
+++ b/syntax.go
@@ -25,13 +25,14 @@ package proto
 
 // Syntax should have value "proto"
 type Syntax struct {
+	LineNumber    int
 	Comment       *Comment
 	Value         string
 	InlineComment *Comment
 }
 
 func (s *Syntax) parse(p *Parser) error {
-	if tok, lit := p.scanIgnoreWhitespace(); tok != tEQUALS {
+	if _, tok, lit := p.scanIgnoreWhitespace(); tok != tEQUALS {
 		return p.unexpected(lit, "syntax =", s)
 	}
 	lit, ok := p.s.scanLiteral()


### PR DESCRIPTION
This PR adds a line number to all Visitees. #7 

Initially I had some code that accessed the line through scanner in the `Parser` struct when creating a new Visitee. That led to some off by one errors as sometimes when creating the Visitee the scanner had already scanned a newline. That is why I added line on the scan function, so it would pass the line for the starting token while scanning. It's not the nicest solution, maybe a more experienced gopher will be able to make it better.

I'm not planning to work any more on this right now, but putting up a pr so anyone can continue with this code if they wish.