### PR TITLE
Move startPosition to test file

### DIFF
--- a/comment_test.go
+++ b/comment_test.go
@@ -25,7 +25,10 @@ package proto
 
 import (
 	"testing"
+	"text/scanner"
 )
+
+var startPosition = scanner.Position{Line: 1, Column: 1}
 
 func TestCreateComment(t *testing.T) {
 	c0 := newComment(startPosition, "")

--- a/parser.go
+++ b/parser.go
@@ -33,8 +33,6 @@ import (
 	"text/scanner"
 )
 
-var startPosition = scanner.Position{Line: 1, Column: 1}
-
 // Parser represents a parser.
 type Parser struct {
 	debug         bool


### PR DESCRIPTION
`startPosition` is only used in tests, it was confusing to see it in `parser.go` and it not be used.