### PR TITLE
Make parser error compatible with linters and fix exit codes

### DIFF
--- a/cmd/proto2gql/main.go
+++ b/cmd/proto2gql/main.go
@@ -123,13 +123,14 @@ func main() {
 
 	for _, filename := range flag.Args() {
 		if err = readAndTransform(filename, transformer); err != nil {
-			fmt.Println(fmt.Sprintf("failed to transform %s file : %s", filename, err.Error()))
-
+			fmt.Println(err.Error())
 			break
 		}
 	}
 
-	err = saveWriters(writers)
+	if saveErr := saveWriters(writers); saveErr != nil && err == nil {
+		err = saveErr
+	}
 
 	if err != nil {
 		os.Exit(1)

--- a/cmd/proto2xsd/main.go
+++ b/cmd/proto2xsd/main.go
@@ -49,11 +49,14 @@ func main() {
 		flag.Usage()
 		os.Exit(0)
 	}
+	exitCode := 0
 	for _, each := range flag.Args() {
 		if err := readConvertWrite(each); err != nil {
-			println(each, err.Error())
+			println(err.Error())
+			exitCode = 1
 		}
 	}
+	os.Exit(exitCode)
 }
 
 func readConvertWrite(filename string) error {

--- a/cmd/protofmt/main.go
+++ b/cmd/protofmt/main.go
@@ -47,11 +47,14 @@ func main() {
 		flag.Usage()
 		os.Exit(0)
 	}
+	exitCode := 0
 	for _, each := range flag.Args() {
 		if err := readFormatWrite(each); err != nil {
-			println(each, err.Error())
+			println(err.Error())
+			exitCode = 1
 		}
 	}
+	os.Exit(exitCode)
 }
 
 func readFormatWrite(filename string) error {

--- a/parser.go
+++ b/parser.go
@@ -113,7 +113,7 @@ func (p *Parser) unexpected(found, expected string, obj interface{}) error {
 		_, file, line, _ := runtime.Caller(1)
 		debug = fmt.Sprintf(" at %s:%d (with %#v)", file, line, obj)
 	}
-	return fmt.Errorf("found %q on %v, expected [%s]%s", found, p.scanner.Position, expected, debug)
+	return fmt.Errorf("%v: Found %q but expected [%s]%s.", p.scanner.Position, found, expected, debug)
 }
 
 func (p *Parser) nextInteger() (i int, err error) {


### PR DESCRIPTION
https://github.com/emicklei/proto/issues/15

This also makes `protofmt` and `proto2xsd` exit with a non-zero exit code if the file cannot be parsed, as well as fixing a bug in `proto2gql` where the intention was to do this, but if `saveWriters` did not error and there was an error with transforming, the result would be to exit with a zero exit code.