### PR TITLE
Add Filename field to Proto struct

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -68,7 +68,7 @@ func (p *Parser) handleScanError(s *scanner.Scanner, msg string) {
 func (p *Parser) Parse() (*Proto, error) {
 	proto := new(Proto)
 	if p.scanner.Filename != "" {
-		proto.Filename = ""
+		proto.Filename = p.scanner.Filename
 	}
 	parseError := proto.parse(p)
 	// see if it was a scanner error

--- a/parser.go
+++ b/parser.go
@@ -67,6 +67,9 @@ func (p *Parser) handleScanError(s *scanner.Scanner, msg string) {
 // Parse parses a proto definition. May return a parse or scanner error.
 func (p *Parser) Parse() (*Proto, error) {
 	proto := new(Proto)
+	if p.scanner.Filename != "" {
+		proto.Filename = ""
+	}
 	parseError := proto.parse(p)
 	// see if it was a scanner error
 	if len(p.scannerErrors) > 0 {

--- a/proto.go
+++ b/proto.go
@@ -25,6 +25,7 @@ package proto
 
 // Proto represents a .proto definition
 type Proto struct {
+	Filename string
 	Elements []Visitee
 }
 


### PR DESCRIPTION
There are times when you have functions that just depend on `*proto.Proto` and you need the filename at the top level for reporting. I ran into this when writing a linter that verified that a certain file option was seen, which means there is no associated `scanner.Position` with the lint failure, so I need to construct my own, and need the filename.