### PR TITLE
Enable parsing package names with a reserved prefix

### DIFF
--- a/package_test.go
+++ b/package_test.go
@@ -23,41 +23,21 @@
 
 package proto
 
-import "text/scanner"
+import (
+	"testing"
+)
 
-// Package specifies the namespace for all proto elements.
-type Package struct {
-	Position      scanner.Position
-	Comment       *Comment
-	Name          string
-	InlineComment *Comment
-	Parent        Visitee
-}
+func TestPackageParseWithReservedPrefix(t *testing.T) {
+	want := "rpc.enum.oneof"
+	ident := " " + want + ";"
 
-// Doc is part of Documented
-func (p *Package) Doc() *Comment {
-	return p.Comment
-}
-
-func (p *Package) parse(pr *Parser) error {
-	_, tok, lit := pr.nextIdent(true)
-	if tIDENT != tok {
-		if !isKeyword(tok) {
-			return pr.unexpected(lit, "package identifier", p)
-		}
+	pkg := new(Package)
+	p := newParserOn(ident)
+	if err := pkg.parse(p); err != nil {
+		t.Error(err)
 	}
-	p.Name = lit
-	return nil
-}
 
-// Accept dispatches the call to the visitor.
-func (p *Package) Accept(v Visitor) {
-	v.VisitPackage(p)
+	if pkg.Name != want {
+		t.Errorf("got %q want %q", pkg.Name, want)
+	}
 }
-
-// inlineComment is part of commentInliner.
-func (p *Package) inlineComment(c *Comment) {
-	p.InlineComment = c
-}
-
-func (p *Package) parent(v Visitee) { p.Parent = v }


### PR DESCRIPTION
See #89 and uber/prototool#103.

This enables parsing package names that begin with a reserved keyword (eg `group.foo` or `rpc.bar`). Previous behaviour would stop parsing after the reserved keyword.

Verified this fix using prototool.