### PR TITLE
fix for single-quoted constants with symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ errcheck: testdeps
 
 .PHONY: staticcheck
 staticcheck: testdeps
-	staticcheck ./...
+	staticcheck -fail "" ./...
 
 .PHONY: unused
 unused: testdeps

--- a/option_test.go
+++ b/option_test.go
@@ -63,6 +63,21 @@ func TestOptionCases(t *testing.T) {
 		"(my.enum.service.is.like).rpc",
 		"",
 		"1",
+	}, {
+		`option (imported.oss.package).action = "literal-double-quotes";`,
+		"(imported.oss.package).action",
+		"literal-double-quotes",
+		"",
+	}, {
+		`option (imported.oss.package).action = 'literalsinglequotes';`,
+		"(imported.oss.package).action",
+		"literalsinglequotes",
+		"",
+	}, {
+		`option (imported.oss.package).action = 'single-quotes.with/symbols';`,
+		"(imported.oss.package).action",
+		"single-quotes.with/symbols",
+		"",
 	}} {
 		p := newParserOn(each.proto)
 		pr, err := p.Parse()

--- a/parser.go
+++ b/parser.go
@@ -138,9 +138,20 @@ func (p *Parser) nextSingleQuotedString() (pos scanner.Position, tok token, lit 
 		// empty single quoted string
 		return p.scanner.Position, tIDENT, "''"
 	}
-	ch = p.scanner.Scan()
-	if ch == scanner.EOF {
-		return p.scanner.Position, tEOF, ""
+
+	// scan for partial tokens until actual closing single-quote(') token
+	for {
+		ch = p.scanner.Scan()
+
+		if ch == scanner.EOF {
+			return p.scanner.Position, tEOF, ""
+		}
+
+		partial := p.scanner.TokenText()
+		if partial == "'" {
+			break
+		}
+		lit += partial
 	}
 	// end quote expected
 	if stringWithSingleQuote != p.scanner.TokenText() {


### PR DESCRIPTION
- Added loop for partial tokens scan+append until actual closing single-quote(`'`)
- Added unit tests for options

Intended as fix for #100 