### PR TITLE
Fix issue #103

### DIFF
--- a/option_test.go
+++ b/option_test.go
@@ -69,6 +69,11 @@ func TestOptionCases(t *testing.T) {
 		"literal-double-quotes",
 		"",
 	}, {
+		`option (imported.oss.package).action = "key:\"literal-double-quotes-escaped\"";`,
+		"(imported.oss.package).action",
+		`key:\"literal-double-quotes-escaped\"`,
+		"",
+	}, {
 		`option (imported.oss.package).action = 'literalsinglequotes';`,
 		"(imported.oss.package).action",
 		"literalsinglequotes",
@@ -581,7 +586,7 @@ func TestOptionWithRepeatedMessageValues(t *testing.T) {
 
 func TestOptionWithRepeatedMessageValuesWithArray(t *testing.T) {
 	src := `message Foo {
-		int64 a = 1 [ (bar.repeated_field_dep_option) = 
+		int64 a = 1 [ (bar.repeated_field_dep_option) =
 			{ hello: 1, repeated_dep: [
 				{ hello: 1, repeated_bar: [1, 2] },
 				{ hello: 3, repeated_bar: [3, 4] } ] } ];

--- a/token.go
+++ b/token.go
@@ -120,7 +120,24 @@ func isComment(lit string) bool {
 }
 
 func unQuote(lit string) string {
-	return strings.Trim(lit, "\"'")
+	lit = strings.TrimLeft(lit, "\"'")
+	array := []rune(lit)
+	// https://github.com/emicklei/proto/issues/103
+	// cannot use strconv.Unquote as this unescapes quotes
+	for len(array) > 0 {
+		last := array[len(array)-1]
+		if last != '\'' && last != '"' {
+			break
+		}
+		if len(array) > 1 {
+			secondLast := array[len(array)-2]
+			if secondLast == '\\' {
+				break
+			}
+		}
+		array = array[:len(array)-1]
+	}
+	return string(array)
 }
 
 func asToken(literal string) token {


### PR DESCRIPTION
Fixes #103.

Please carefully look this over and make sure it seems reasonable.

You shouldn't have to worry about leading `\"` because `strings.TrimLeft` will hit the `\` before the `"`.