### PR TITLE
Fix parsing of empty arrays in options

### DIFF
--- a/option.go
+++ b/option.go
@@ -169,6 +169,18 @@ func (l *Literal) parse(p *Parser) error {
 	if tok == tLEFTSQUARE {
 		// collect array elements
 		array := []*Literal{}
+
+		// if it's an empty array, consume the close bracket, set the Array to
+		// an empty array, and return
+		r := p.peekNonWhitespace()
+		if ']' == r {
+			pos, _, _ := p.next()
+			l.Array = array
+			l.IsString = false
+			l.Position = pos
+			return nil
+		}
+
 		for {
 			e := new(Literal)
 			if err := e.parse(p); err != nil {

--- a/option_test.go
+++ b/option_test.go
@@ -33,57 +33,63 @@ func TestOptionCases(t *testing.T) {
 		name      string
 		strLit    string
 		nonStrLit string
-	}{{
-		`option (full).java_package = "com.example.foo";`,
-		"(full).java_package",
-		"com.example.foo",
-		"",
-	}, {
-		`option Bool = true;`,
-		"Bool",
-		"",
-		"true",
-	}, {
-		`option Float = -3.14E1;`,
-		"Float",
-		"",
-		"-3.14E1",
-	}, {
-		`option (foo_options) = { opt1: 123 opt2: "baz" };`,
-		"(foo_options)",
-		"",
-		"",
-	}, {
-		`option optimize_for = SPEED;`,
-		"optimize_for",
-		"",
-		"SPEED",
-	}, {
-		"option (my.enum.service.is.like).rpc = 1;",
-		"(my.enum.service.is.like).rpc",
-		"",
-		"1",
-	}, {
-		`option (imported.oss.package).action = "literal-double-quotes";`,
-		"(imported.oss.package).action",
-		"literal-double-quotes",
-		"",
-	}, {
-		`option (imported.oss.package).action = "key:\"literal-double-quotes-escaped\"";`,
-		"(imported.oss.package).action",
-		`key:\"literal-double-quotes-escaped\"`,
-		"",
-	}, {
-		`option (imported.oss.package).action = 'literalsinglequotes';`,
-		"(imported.oss.package).action",
-		"literalsinglequotes",
-		"",
-	}, {
-		`option (imported.oss.package).action = 'single-quotes.with/symbols';`,
-		"(imported.oss.package).action",
-		"single-quotes.with/symbols",
-		"",
-	}} {
+	}{
+		{
+			`option (full).java_package = "com.example.foo";`,
+			"(full).java_package",
+			"com.example.foo",
+			"",
+		}, {
+			`option Bool = true;`,
+			"Bool",
+			"",
+			"true",
+		}, {
+			`option Float = -3.14E1;`,
+			"Float",
+			"",
+			"-3.14E1",
+		}, {
+			`option (foo_options) = { opt1: 123 opt2: "baz" };`,
+			"(foo_options)",
+			"",
+			"",
+		}, {
+			`option foo = []`,
+			"foo",
+			"",
+			"",
+		}, {
+			`option optimize_for = SPEED;`,
+			"optimize_for",
+			"",
+			"SPEED",
+		}, {
+			"option (my.enum.service.is.like).rpc = 1;",
+			"(my.enum.service.is.like).rpc",
+			"",
+			"1",
+		}, {
+			`option (imported.oss.package).action = "literal-double-quotes";`,
+			"(imported.oss.package).action",
+			"literal-double-quotes",
+			"",
+		}, {
+			`option (imported.oss.package).action = "key:\"literal-double-quotes-escaped\"";`,
+			"(imported.oss.package).action",
+			`key:\"literal-double-quotes-escaped\"`,
+			"",
+		}, {
+			`option (imported.oss.package).action = 'literalsinglequotes';`,
+			"(imported.oss.package).action",
+			"literalsinglequotes",
+			"",
+		}, {
+			`option (imported.oss.package).action = 'single-quotes.with/symbols';`,
+			"(imported.oss.package).action",
+			"single-quotes.with/symbols",
+			"",
+		}} {
 		p := newParserOn(each.proto)
 		pr, err := p.Parse()
 		if err != nil {

--- a/option_test.go
+++ b/option_test.go
@@ -33,63 +33,62 @@ func TestOptionCases(t *testing.T) {
 		name      string
 		strLit    string
 		nonStrLit string
-	}{
-		{
-			`option (full).java_package = "com.example.foo";`,
-			"(full).java_package",
-			"com.example.foo",
-			"",
-		}, {
-			`option Bool = true;`,
-			"Bool",
-			"",
-			"true",
-		}, {
-			`option Float = -3.14E1;`,
-			"Float",
-			"",
-			"-3.14E1",
-		}, {
-			`option (foo_options) = { opt1: 123 opt2: "baz" };`,
-			"(foo_options)",
-			"",
-			"",
-		}, {
-			`option foo = []`,
-			"foo",
-			"",
-			"",
-		}, {
-			`option optimize_for = SPEED;`,
-			"optimize_for",
-			"",
-			"SPEED",
-		}, {
-			"option (my.enum.service.is.like).rpc = 1;",
-			"(my.enum.service.is.like).rpc",
-			"",
-			"1",
-		}, {
-			`option (imported.oss.package).action = "literal-double-quotes";`,
-			"(imported.oss.package).action",
-			"literal-double-quotes",
-			"",
-		}, {
-			`option (imported.oss.package).action = "key:\"literal-double-quotes-escaped\"";`,
-			"(imported.oss.package).action",
-			`key:\"literal-double-quotes-escaped\"`,
-			"",
-		}, {
-			`option (imported.oss.package).action = 'literalsinglequotes';`,
-			"(imported.oss.package).action",
-			"literalsinglequotes",
-			"",
-		}, {
-			`option (imported.oss.package).action = 'single-quotes.with/symbols';`,
-			"(imported.oss.package).action",
-			"single-quotes.with/symbols",
-			"",
-		}} {
+	}{{
+		`option (full).java_package = "com.example.foo";`,
+		"(full).java_package",
+		"com.example.foo",
+		"",
+	}, {
+		`option Bool = true;`,
+		"Bool",
+		"",
+		"true",
+	}, {
+		`option Float = -3.14E1;`,
+		"Float",
+		"",
+		"-3.14E1",
+	}, {
+		`option (foo_options) = { opt1: 123 opt2: "baz" };`,
+		"(foo_options)",
+		"",
+		"",
+	}, {
+		`option foo = []`,
+		"foo",
+		"",
+		"",
+	}, {
+		`option optimize_for = SPEED;`,
+		"optimize_for",
+		"",
+		"SPEED",
+	}, {
+		"option (my.enum.service.is.like).rpc = 1;",
+		"(my.enum.service.is.like).rpc",
+		"",
+		"1",
+	}, {
+		`option (imported.oss.package).action = "literal-double-quotes";`,
+		"(imported.oss.package).action",
+		"literal-double-quotes",
+		"",
+	}, {
+		`option (imported.oss.package).action = "key:\"literal-double-quotes-escaped\"";`,
+		"(imported.oss.package).action",
+		`key:\"literal-double-quotes-escaped\"`,
+		"",
+	}, {
+		`option (imported.oss.package).action = 'literalsinglequotes';`,
+		"(imported.oss.package).action",
+		"literalsinglequotes",
+		"",
+	}, {
+		`option (imported.oss.package).action = 'single-quotes.with/symbols';`,
+		"(imported.oss.package).action",
+		"single-quotes.with/symbols",
+		"",
+	}} {
 		p := newParserOn(each.proto)
 		pr, err := p.Parse()
 		if err != nil {


### PR DESCRIPTION
I found an error in the parser on empty arrays with my proto files on a section that looked like:

```
  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
    json_schema : {
      title : "Frob a request"
      description : "blah blah blah"
      required : [ ]
    }
  };
```

So I boiled the bug down to the example I gave in the test, and fixed it the simplest way I could.

I wasn't able to easily test that an empty array was actually created, since there are neither string literals nor non-string literals created in the parsing process; I wasn't sure if you would want me to try and add that or not.

I'd be happy to if you think I should, please advise on how you'd do it if so.