### PR TITLE
fix 0X

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -193,7 +193,7 @@ func (p *Parser) nextInteger() (i int, err error) {
 	if tok != tIDENT {
 		return 0, errors.New("non integer")
 	}
-	if strings.HasPrefix(lit, "0x") {
+	if strings.HasPrefix(lit, "0x") || strings.HasPrefix(lit, "0X") {
 		// hex decode
 		i64, err := strconv.ParseInt(lit, 0, 64)
 		return int(i64), err

--- a/parser_test.go
+++ b/parser_test.go
@@ -181,3 +181,18 @@ func TestParseSingleQuotesStrings(t *testing.T) {
 		t.Errorf("got [%v] want [%v]", got, want)
 	}
 }
+
+func TestProtoIssue132(t *testing.T) {
+	src := `syntax = "proto3";
+package tutorial;
+message Person {
+  string name = 1;
+  int32 id = 0x2;  // Unique ID number for this person.
+  string email = 0X3; // parser.Parse err <input>:8:18: found "=" but expected [field sequence number]
+}`
+	p := newParserOn(src)
+	_, err := p.Parse()
+	if err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
case:
```syntax = "proto2";

package tutorial;

message Person {
  string name = 1;
  int32 id = 0x2;  // Unique ID number for this person.
  string email = 0X3; // parser.Parse err <input>:8:18: found "=" but expected [field sequence number]
}
