### PR TITLE
isNumber Method Incorrectly Identifies "Inf" as a Number, Causing Errors in Parser Handling of the "Inf" Identifier

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -229,3 +229,29 @@ enum Value {
 		t.Fatal(err) // <input>:7:16: found "-" but expected [range integer]
 	}
 }
+
+func TestParseInfMessage(t *testing.T) {
+	const def = `
+message Inf {
+	string field = 1; 
+}
+message NaN {
+	string field = 1; 
+}
+
+message Infinity {
+	string field = 1; 
+}
+message ExampelMessage {
+	Inf inf_field = 1;
+	NaN nan_field = 2; 
+	Infinity infinity_field = 3; 
+}
+`
+
+	p := NewParser(strings.NewReader(def))
+	_, err := p.Parse()
+	if err != nil {
+		t.Fatal(err) // <input>:7:16: found "-" but expected [range integer]
+	}
+}

--- a/token.go
+++ b/token.go
@@ -124,6 +124,9 @@ func isComment(lit string) bool {
 }
 
 func isNumber(lit string) bool {
+	if lit == "NaN" || lit == "nan" || lit == "Inf" || lit == "Infinity" || lit == "inf" || lit == "infinity" {
+		return false
+	}
 	if strings.HasPrefix(lit, "0x") || strings.HasPrefix(lit, "0X") {
 		_, err := strconv.ParseInt(lit, 0, 64)
 		return err == nil

--- a/token_test.go
+++ b/token_test.go
@@ -63,6 +63,12 @@ func TestIsNumber(t *testing.T) {
 		{`a1`, false},
 		{`0x12`, true},
 		{`0X77777`, true},
+		{`NaN`, false},
+		{`nan`, false},
+		{`Inf`, false},
+		{`Infinity`, false},
+		{`inf`, false},
+		{`infinity`, false},
 	} {
 		got := isNumber(each.input)
 		if got != each.isNumber {


### PR DESCRIPTION
# `isNumber` Method Incorrectly Identifies `"Inf"` as a Number, Causing Errors in Parser Handling of the `"Inf"` Identifier

**Problem Description:**

When running the unit test `TestParseInf`, the parser throws an unexpected error. After debugging, it was found that the `isNumber` method in the `proto/token.go` file incorrectly identifies the string `"Inf"` as a number, leading to a parsing logic error.

**Reproduction Steps:**

1. Add the following unit test to the project:

    ```go:proto/parser_test.go
    func TestParseInf(t *testing.T) {
        const def = `
    message Inf {
       string field = 1; 
    }
    message Example {
        repeated Inf inf_1 = 1; 
    }`

        p := NewParser(strings.NewReader(def))
        _, err := p.Parse()
        if err != nil {
            t.Fatal(err) // <input>:6:21: found "=" but expected [field identifier]
        }
    }
    ```

2. Run the unit test:

    ```shell
    go test proto/parser_test.go
    ```

3. The test fails with the following error message:

    ```
    <input>:6:21: found "=" but expected [field identifier]
    ```

**Cause Analysis:**

The `isNumber` method uses `strconv.ParseFloat` to determine if a string is a number. However, `strconv.ParseFloat("Inf", 64)` returns positive infinity `+Inf` and does not return an error. As a result, the string `"Inf"` is incorrectly identified as a number.

```go:proto/token.go
func isNumber(lit string) bool {
    if strings.HasPrefix(lit, "0x") || strings.HasPrefix(lit, "0X") {
        _, err := strconv.ParseInt(lit, 0, 64)
        return err == nil
    }
    _, err := strconv.ParseFloat(lit, 64)
    return err == nil
}
```

**Expected Behavior:**

The `isNumber` method should accurately identify numeric strings and avoid misidentifying special strings like `"Inf"` and `"NaN"` as numbers. The string `"Inf"` should be treated as an identifier, not a number.

**Proposed Solution:**

Add exclusion checks for special strings in the `isNumber` method:

```go:proto/token.go
func isNumber(lit string) bool {
    if lit == "NaN" || lit == "nan" || lit == "Inf" || lit == "Infinity" || lit == "inf" || lit == "infinity" {
        return false
    }
    if strings.HasPrefix(lit, "0x") || strings.HasPrefix(lit, "0X") {
        _, err := strconv.ParseInt(lit, 0, 64)
        return err == nil
    }
    _, err := strconv.ParseFloat(lit, 64)
    return err == nil
}
```

**Notes:**

- After this modification, `isNumber("Inf")` will return `false`, preventing the logical error.
- Rerun the unit test, and it should pass.

**Environment Information:**

- Go Version: 1.20
- Operating System: Ubuntu 20.04

**Request:**

I hope the `isNumber` method can be corrected to properly handle special strings like `"Inf"` to ensure the parser's accuracy.

Thank you for the team's efforts!
